### PR TITLE
Change book title in `add_book_spec.rb`

### DIFF
--- a/content/introduction/getting-started.md
+++ b/content/introduction/getting-started.md
@@ -707,14 +707,14 @@ RSpec.describe 'Add a book' do
     visit '/books/new'
 
     within 'form#book-form' do
-      fill_in 'Title',  with: 'New book'
+      fill_in 'Title',  with: 'Example book'
       fill_in 'Author', with: 'Some author'
 
       click_button 'Create'
     end
 
     expect(page).to have_current_path('/books')
-    expect(page).to have_content('New book')
+    expect(page).to have_content('Example book')
   end
 end
 ```


### PR DESCRIPTION
Small thing: the `add_book_spec.rb` can give a false positive because the link text to create a book is "New book" in `apps/web/templates/books/index.html.erb`, so even if the add failed and `books/index.html.erb` is rendered, this test would pass. I modified the title to differentiate it from the link.